### PR TITLE
Correct path to sample-app/ in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -89,7 +89,7 @@ Copy contents from aws-kube-codesuite/sample-app to this repository folder.
 
     cp -r aws-kube-codesuite/* codesuite-demo/
 
-Make a change to the `codesuite-demo/hello.py` file and then change into that directory `cd codesuite-demo`
+Make a change to the `codesuite-demo/sample-app/hello.py` file and then change into that directory `cd codesuite-demo`
 
 Add, commit and push:
 

--- a/README.adoc
+++ b/README.adoc
@@ -87,9 +87,9 @@ This creates a directory named `codesuite-demo` in your current directory.
 
 Copy contents from aws-kube-codesuite/sample-app to this repository folder.
 
-    cp -r aws-kube-codesuite/* codesuite-demo/
+    cp aws-kube-codesuite/sample-app/* codesuite-demo/
 
-Make a change to the `codesuite-demo/sample-app/hello.py` file and then change into that directory `cd codesuite-demo`
+Make a change to the `codesuite-demo/hello.py` file and then change into that directory `cd codesuite-demo`
 
 Add, commit and push:
 

--- a/README.adoc
+++ b/README.adoc
@@ -87,7 +87,7 @@ This creates a directory named `codesuite-demo` in your current directory.
 
 Copy contents from aws-kube-codesuite/sample-app to this repository folder.
 
-    cp aws-kube-codesuite/* codesuite-demo/
+    cp -r aws-kube-codesuite/* codesuite-demo/
 
 Make a change to the `codesuite-demo/hello.py` file and then change into that directory `cd codesuite-demo`
 


### PR DESCRIPTION
*Description of changes:*

README tutorial edit: 
- Add missing dir path /sample-app in copy instructions 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
