### PR TITLE
Fixes #10

### DIFF
--- a/eks/templates/aws-refarch-codesuite-kubernetes.yaml
+++ b/eks/templates/aws-refarch-codesuite-kubernetes.yaml
@@ -45,14 +45,14 @@ Resources:
   LambdaCopy:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: https://s3.amazonaws.com/aws-eks-codesuite/lambda-copy.yaml
+      TemplateURL: https://aws-eks-codesuite.s3.amazonaws.com/lambda-copy.yaml
       Parameters:
         TemplateBucket: !Ref TemplateBucket
 
   Pipeline:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: https://s3.amazonaws.com/aws-eks-codesuite/deployment-pipeline.yaml
+      TemplateURL: https://aws-eks-codesuite.s3.amazonaws.com/deployment-pipeline.yaml
       Parameters:
             Name: !Ref AWS::StackName
             TemplateBucket: !Ref TemplateBucket


### PR DESCRIPTION
*Issue #10:*

*Description of changes:*

Fix 'S3 error: Unable to get the object https://s3.amazonaws.com/aws-eks-codesuite/lambda-copy.yaml' on creating a stack from Template for Amazon EKS.